### PR TITLE
Fixed error with get_prototyping_instructions_for_github_and_labs tool

### DIFF
--- a/src/mcp_foundry/mcp_foundry_model/tools.py
+++ b/src/mcp_foundry/mcp_foundry_model/tools.py
@@ -231,7 +231,7 @@ def get_prototyping_instructions_for_github_and_labs(ctx: Context) -> str:
         return f"Error fetching instructions from API: {response.status_code}"
 
     copilot_instructions = response.json()
-    return copilot_instructions["resource"]
+    return copilot_instructions["resource"]["content"]
 
 @mcp.tool()
 def get_model_quotas(subscription_id: str, location: str) -> list[dict]:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Fixed one-line bug with the MCP tool function "get_prototyping_instructions_for_github_and_labs".

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* In your .vscode/mcp.json, temporarily change the github repo URL to this branch by using this URL instead: "git+https://github.com/dennischenfeng/mcp-foundry.git@copilot-instructions-fix". This makes it so next time the MCP server is started, it should install from the branch instead
* In the GitHub copilot chat window, in agent mode and ensuring the tools are enabled, ask "please try to use the tool to get prototyping instructions". It should invoke and successfully grab the instructions.

## Other Information
<!-- Add any other helpful information that may be needed here. -->