### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ The rest of this repo (including codebase) explains the now-deprecated MCP Serve
 
 See [More examples for advanced setup](./clients/README.md) for more details on how to set up the MCP server.
 
+### Usage with GitHub Copilot CLI
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "mcp_foundry_server": {
+      "command": "uvx",
+      "args": [
+        "--prerelease=allow",
+        "--from",
+        "git+https://github.com/azure-ai-foundry/mcp-foundry.git",
+        "run-azure-ai-foundry-mcp"
+      ]
+    }
+  }
+}
+```
+
+For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
 ## Setting the Environment Variables
 
 To securely pass information to the MCP server, such as API keys, endpoints, and other sensitive data, you can use environment variables. This is especially important for tools that require authentication or access to external services.


### PR DESCRIPTION
## Purpose
Adds GitHub Copilot CLI installation instructions to the README, following the existing pattern for VS Code setup.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* View the rendered README.md on GitHub
* Verify JSON configuration is valid

## What to Check
* Markdown renders correctly
* JSON config matches existing patterns in the repo

## Other Information
N/A - Documentation-only change